### PR TITLE
Make build.rs a bit more resilient when used outside of an EVerest workspace

### DIFF
--- a/everestrs/everestrs/build.rs
+++ b/everestrs/everestrs/build.rs
@@ -51,7 +51,7 @@ fn find_libs_in_everest_framework(root: &Path) -> Option<Libraries> {
     }
 }
 
-fn find_libs_in_lib_dir(lib_dir: &Path) -> Option<Libraries> {
+fn find_libs_in_dir(lib_dir: &Path) -> Option<Libraries> {
     let everestrs_sys = lib_dir.join("libeverestrs_sys.a");
     let framework = lib_dir.join("libframework.so");
     if everestrs_sys.exists() && framework.exists() {
@@ -67,7 +67,7 @@ fn find_libs_in_lib_dir(lib_dir: &Path) -> Option<Libraries> {
 /// Returns the Libraries path if this is an EVerest workspace where make install was run in
 /// everest-core/build or None if not.
 fn find_libs_in_everest_core_build_dist(root: &Path) -> Option<Libraries> {
-    find_libs_in_lib_dir(&root.join("everest-core/build/dist/lib"))
+    find_libs_in_dir(&root.join("everest-core/build/dist/lib"))
 }
 
 /// Takes a path to a library like `libframework.so` and returns the name for the linker, aka
@@ -107,7 +107,7 @@ fn main() {
     }
 
     let libs = match env::var("EVEREST_LIB_DIR") {
-        Ok(p) => find_libs_in_lib_dir(&Path::new(&p)),
+        Ok(p) => find_libs_in_dir(&Path::new(&p)),
         Err(_) => find_libs_in_everest_workspace(),
     };
 

--- a/everestrs/everestrs/build.rs
+++ b/everestrs/everestrs/build.rs
@@ -51,11 +51,9 @@ fn find_libs_in_everest_framework(root: &Path) -> Option<Libraries> {
     }
 }
 
-/// Returns the Libraries path if this is an EVerest workspace where make install was run in
-/// everest-core/build or None if not.
-fn find_libs_in_everest_core_build_dist(root: &Path) -> Option<Libraries> {
-    let everestrs_sys = root.join("everest-core/build/dist/lib/libeverestrs_sys.a");
-    let framework = root.join("everest-core/build/dist/lib/libframework.so");
+fn find_libs_in_lib_dir(lib_dir: &Path) -> Option<Libraries> {
+    let everestrs_sys = lib_dir.join("libeverestrs_sys.a");
+    let framework = lib_dir.join("libframework.so");
     if everestrs_sys.exists() && framework.exists() {
         Some(Libraries {
             everestrs_sys,
@@ -64,6 +62,12 @@ fn find_libs_in_everest_core_build_dist(root: &Path) -> Option<Libraries> {
     } else {
         None
     }
+}
+
+/// Returns the Libraries path if this is an EVerest workspace where make install was run in
+/// everest-core/build or None if not.
+fn find_libs_in_everest_core_build_dist(root: &Path) -> Option<Libraries> {
+    find_libs_in_lib_dir(&root.join("everest-core/build/dist/lib"))
 }
 
 /// Takes a path to a library like `libframework.so` and returns the name for the linker, aka
@@ -85,13 +89,13 @@ fn print_link_options(p: &Path) {
     println!("cargo:rustc-link-lib={}", libname_from_path(p));
 }
 
-fn find_libs(root: &Path) -> Libraries {
+fn find_libs_in_everest_workspace() -> Option<Libraries> {
+    let root = find_everest_workspace_root();
     let libs = find_libs_in_everest_core_build_dist(&root);
     if libs.is_some() {
-        return libs.unwrap();
+        return libs;
     }
     find_libs_in_everest_framework(&root)
-        .expect("everestrs is not build in a EVerest workspace that already ran cmake build")
 }
 
 fn main() {
@@ -102,8 +106,14 @@ fn main() {
         return;
     }
 
-    let root = find_everest_workspace_root();
-    let libs = find_libs(&root);
+    let libs = match env::var("EVEREST_LIB_DIR") {
+        Ok(p) => find_libs_in_lib_dir(&Path::new(&p)),
+        Err(_) => find_libs_in_everest_workspace(),
+    };
+
+    let libs = libs
+        .expect("Could not find libframework.so and libeverestrs_sys. Either set EVEREST_LIB_DIR to a path
+        that contains them or run the build again with everestrs being inside an everest workspace.");
 
     print_link_options(&libs.everestrs_sys);
     print_link_options(&libs.framework);


### PR DESCRIPTION
Now EVEREST_LIB_DIR can be set to point directly to the libframework.so and libeverestsrs_sys.a. This is useful when you pull in everstrs through an external git repo for example.