### PR TITLE
Fix cmds with no parameters

### DIFF
--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -99,6 +99,8 @@ dependencies = [
  "argh",
  "cxx",
  "everestrs-build",
+ "format_serde_error",
+ "log",
  "serde",
  "serde_json",
  "thiserror",
@@ -115,6 +117,16 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+]
+
+[[package]]
+name = "format_serde_error"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5837b8e6a4001f99fe4746767fb7379e8510c508a843caa136cc12ed9c0bad0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -153,6 +165,12 @@ checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "minijinja"

--- a/everestrs/Cargo.lock
+++ b/everestrs/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "argh",
  "cxx",
  "everestrs-build",
- "format_serde_error",
  "log",
  "serde",
  "serde_json",
@@ -117,16 +116,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
-]
-
-[[package]]
-name = "format_serde_error"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5837b8e6a4001f99fe4746767fb7379e8510c508a843caa136cc12ed9c0bad0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/everestrs/everestrs/BUILD.bazel
+++ b/everestrs/everestrs/BUILD.bazel
@@ -7,6 +7,7 @@ rust_library(
     edition = "2021",
     deps =  [
         "@crate_index//:argh",
+        "@crate_index//:log",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:thiserror",

--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 [dependencies]
 argh = "0.1.10"
 cxx = { version = "1.0.107", features = ["c++17"] }
+everestrs-build = { workspace = true }
+log = "0.4.20"
 serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0.48"
-everestrs-build = { workspace = true }
 
 [features]
 build_bazel = []

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -242,7 +242,7 @@ impl Runtime {
             .unwrap()
             .upgrade()
             .unwrap()
-            .handle_command(impl_id, name, parameters.unwrap_or_else(|| HashMap::new()))
+            .handle_command(impl_id, name, parameters.unwrap_or_default())
             .unwrap();
         ffi::JsonBlob::from_vec(serde_json::to_vec(&blob).unwrap())
     }

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -248,7 +248,10 @@ impl Runtime {
     }
 
     fn handle_variable(&self, impl_id: &str, name: &str, json: ffi::JsonBlob) {
-        debug!("handle_variable: {impl_id}, {name}, '{:?}'", json.as_bytes());
+        debug!(
+            "handle_variable: {impl_id}, {name}, '{:?}'",
+            json.as_bytes()
+        );
         self.sub_impl
             .read()
             .unwrap()

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -1,6 +1,7 @@
 use everestrs_build::schema;
 
 use argh::FromArgs;
+use log::debug;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -231,6 +232,8 @@ impl Runtime {
     }
 
     fn handle_command(&self, impl_id: &str, name: &str, json: ffi::JsonBlob) -> ffi::JsonBlob {
+        debug!("handle_command: {impl_id}, {name}, '{:?}'", json.as_bytes());
+        let parameters: Option<HashMap<String, serde_json::Value>> = json.deserialize();
         let blob = self
             .sub_impl
             .read()
@@ -239,12 +242,13 @@ impl Runtime {
             .unwrap()
             .upgrade()
             .unwrap()
-            .handle_command(impl_id, name, json.deserialize())
+            .handle_command(impl_id, name, parameters.unwrap_or_else(|| HashMap::new()))
             .unwrap();
         ffi::JsonBlob::from_vec(serde_json::to_vec(&blob).unwrap())
     }
 
     fn handle_variable(&self, impl_id: &str, name: &str, json: ffi::JsonBlob) {
+        debug!("handle_variable: {impl_id}, {name}, '{:?}'", json.as_bytes());
         self.sub_impl
             .read()
             .unwrap()


### PR DESCRIPTION
EVerest is sending `null` as parameter for commands that do not take any parameter. However the Rust code is expecting `HashMap<String, Value>`. Fix this problem by deserializing into an Option and if it is None pass on an empty HashMap.

Also:
- Add debug logging for received JSON