### PR TITLE
Add target for schemas

### DIFF
--- a/schemas/BUILD.bazel
+++ b/schemas/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "schemas",
+    srcs = glob(["*.yaml"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
We need schemas in downstream repositories as well to generate loaders for C++ modules.