### PR TITLE
Rust: Add logging

### DIFF
--- a/everestrs/everestrs/Cargo.toml
+++ b/everestrs/everestrs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 argh = "0.1.10"
 cxx = { version = "1.0.107", features = ["c++17"] }
 everestrs-build = { workspace = true }
-log = "0.4.20"
+log = { version = "0.4.20", features = ["std"] }
 serde = { version = "1.0.175", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0.48"

--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -1,7 +1,8 @@
 #include "everestrs/src/everestrs_sys.hpp"
 #include "everestrs/src/lib.rs.h"
 
-#include "utils/types.hpp"
+#include <everest/logging.hpp>
+#include <utils/types.hpp>
 
 #include <cstdlib>
 #include <stdexcept>
@@ -150,4 +151,11 @@ rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_id, rust::Str pref
     }
 
     return out;
+}
+
+void log2cxx(int level, int line, rust::Str file, rust::Str message) {
+    const auto logging_level = static_cast<::Everest::Logging::severity_level>(level);
+    BOOST_LOG_SEV(::global_logger::get(), logging_level)
+        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("file", std::string{file})
+        << boost::log::BOOST_LOG_VERSION_NAMESPACE::add_value("line", line) << std::string{message};
 }

--- a/everestrs/everestrs/src/everestrs_sys.hpp
+++ b/everestrs/everestrs/src/everestrs_sys.hpp
@@ -37,3 +37,5 @@ private:
 std::unique_ptr<Module> create_module(rust::Str module_name, rust::Str prefix, rust::Str conf);
 
 rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_name, rust::Str prefix, rust::Str conf);
+
+void log2cxx(int level, int line, rust::Str file, rust::Str message);

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -144,6 +144,8 @@ mod ffi {
         /// Returns the module config from cpp.
         fn get_module_configs(module_id: &str, prefix: &str, conf: &str) -> Vec<RsModuleConfig>;
 
+        /// Logging sink for the EVerest module.
+        fn log2cxx(level: i32, line: i32, file: &str, message: &str);
     }
 }
 
@@ -159,6 +161,70 @@ impl ffi::JsonBlob {
 
     fn from_vec(data: Vec<u8>) -> Self {
         Self { data }
+    }
+}
+
+/// Very simple logger to use by the Rust modules.
+mod logger {
+    use super::ffi;
+    use std::env;
+
+    pub(crate) struct Logger {
+        level: log::Level,
+    }
+
+    impl log::Log for Logger {
+        fn enabled(&self, metadata: &log::Metadata) -> bool {
+            // Rust gives the Error level 1 and all other severities a higher
+            // value.
+            metadata.level() <= self.level
+        }
+
+        fn log(&self, record: &log::Record) {
+            // This mapping should be kept in sync with liblog's
+            // Everest::Logging::severity_level.
+            let level = match record.level() {
+                log::Level::Trace => 0,
+                log::Level::Debug => 1,
+                log::Level::Info => 2,
+                log::Level::Warn => 3,
+                log::Level::Error => 4,
+            };
+            ffi::log2cxx(
+                level,
+                record.line().unwrap_or_default() as i32,
+                record.file().unwrap_or_default(),
+                &format!("{}", record.args()),
+            )
+        }
+
+        fn flush(&self) {}
+    }
+
+    impl Logger {
+        /// Init the logger for everest.
+        ///
+        /// Don't do this on your own as we must also control some cxx code.
+        /// However, you can set the severity through the env-var
+        /// `EVERESTRS_SEVERITY` to pre-filter logs from Rust. This will reduce
+        /// the number of ffi calls and improve performance.
+        pub(crate) fn init_logger() {
+            let severity = env::var("EVERESTRS_SEVERITY")
+                .unwrap_or("info".to_string())
+                .to_lowercase();
+
+            // Map the string to the severity.
+            let level = match severity.as_str() {
+                "trace" | "verb" => log::Level::Trace,
+                "debug" | "debg" => log::Level::Debug,
+                "info" => log::Level::Info,
+                "warn" | "warning" => log::Level::Warn,
+                _ => log::Level::Error,
+            };
+
+            let logger = Self { level };
+            log::set_boxed_logger(Box::new(logger)).unwrap();
+        }
     }
 }
 
@@ -306,6 +372,8 @@ impl Runtime {
             &args.prefix.to_string_lossy(),
             &args.conf.to_string_lossy(),
         );
+
+        logger::Logger::init_logger();
 
         Arc::pin(Self {
             cpp_module,

--- a/everestrs/everestrs/src/lib.rs
+++ b/everestrs/everestrs/src/lib.rs
@@ -181,6 +181,10 @@ mod logger {
         }
 
         fn log(&self, record: &log::Record) {
+            // The doc says `log` has to perform the filtering itself.
+            if !self.enabled(record.metadata()) {
+                return;
+            }
             // This mapping should be kept in sync with liblog's
             // Everest::Logging::severity_level.
             let level = match record.level() {
@@ -190,6 +194,7 @@ mod logger {
                 log::Level::Warn => 3,
                 log::Level::Error => 4,
             };
+
             ffi::log2cxx(
                 level,
                 record.line().unwrap_or_default() as i32,
@@ -224,6 +229,7 @@ mod logger {
 
             let logger = Self { level };
             log::set_boxed_logger(Box::new(logger)).unwrap();
+            log::set_max_level(level.to_level_filter());
         }
     }
 }


### PR DESCRIPTION
Adds a Rust logger.
The Rust logger would do a "pre-filtering" based on the `EVERESTRS_LOGGING` variable and pass everything which passes that filter on to the cxx code, which uses EVerest's boost impl

Example output to the terminal are 
```sh
2024-03-18 21:12:04.523233 [INFO] RsQevhs          rust/everest/RsQevhs/src/bin/RsQevhs/main.rs:259: this is the info
2024-03-18 21:12:04.523323 [WARN] RsQevhs          rust/everest/RsQevhs/src/bin/RsQevhs/main.rs:260: this is the warn
2024-03-18 21:12:04.523341 [ERRO] RsQevhs          rust/everest/RsQevhs/src/bin/RsQevhs/main.rs:261: this is the error
```