### PR TITLE
Rust: extend logger to use config from boost

### DIFF
--- a/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/everestrs/everestrs/src/everestrs_sys.cpp
@@ -5,9 +5,18 @@
 #include <utils/types.hpp>
 
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <stdexcept>
 #include <type_traits>
 #include <variant>
+
+#include <boost/log/attributes/attribute_value_set.hpp>
+#include <boost/log/attributes/constant.hpp>
+#include <boost/log/expressions/filter.hpp>
+#include <boost/log/utility/setup/filter_parser.hpp>
+#include <boost/log/utility/setup/settings.hpp>
+#include <boost/log/utility/setup/settings_parser.hpp>
 
 namespace {
 
@@ -151,6 +160,48 @@ rust::Vec<RsModuleConfig> get_module_configs(rust::Str module_id, rust::Str pref
     }
 
     return out;
+}
+
+int Module::get_log_level() const {
+    // Below is something really ugly. Boost's log filter rules may actually be
+    // quite "complex" but the library does not expose any way to check the
+    // already installed filters. We therefore reopen the config and construct
+    // or own filter - and feed it with dummy values to determine its filtering
+    // behaviour (the lowest severity which is accepted by the filter)
+    std::filesystem::path logging_path{rs_->logging_config_file};
+    std::ifstream logging_config(logging_path.c_str());
+
+    using namespace boost::log;
+    using namespace Everest::Logging;
+
+    if (!logging_config.is_open()) {
+        return info;
+    }
+    const auto settings = parse_settings(logging_config);
+
+    if (auto core_settings = settings["Core"]) {
+        if (boost::optional<std::string> param = core_settings["Filter"]) {
+
+            const auto filter = parse_filter(param.get());
+            // Check for the severity values - which is the first one to be
+            // accepted by the filter.
+            static_assert(static_cast<int>(verbose) == 0);
+            static_assert(static_cast<int>(error) == 4);
+            for (int ii = static_cast<int>(verbose); ii <= static_cast<int>(error); ++ii) {
+                attribute_set set1, set2, set3;
+                set1["Severity"] = attributes::constant<severity_level>{static_cast<severity_level>(ii)};
+
+                attribute_value_set value_set(set1, set2, set3);
+                value_set.freeze();
+
+                if (filter(value_set)) {
+                    return ii;
+                }
+            }
+        }
+    }
+
+    return info;
 }
 
 void log2cxx(int level, int line, rust::Str file, rust::Str message) {

--- a/everestrs/everestrs/src/everestrs_sys.hpp
+++ b/everestrs/everestrs/src/everestrs_sys.hpp
@@ -26,6 +26,7 @@ public:
     JsonBlob call_command(rust::Str implementation_id, rust::Str name, JsonBlob args) const;
     void subscribe_variable(const Runtime& rt, rust::String implementation_id, rust::String name) const;
     void publish_variable(rust::Str implementation_id, rust::Str name, JsonBlob blob) const;
+    int get_log_level() const;
 
 private:
     const std::string module_id_;


### PR DESCRIPTION
Use the same config and determine what is the minimal severity level for logging and pass this on to Rust